### PR TITLE
feat: 커플 생성 API

### DIFF
--- a/src/main/java/com/lovemarker/LovemarkerApplication.java
+++ b/src/main/java/com/lovemarker/LovemarkerApplication.java
@@ -2,9 +2,7 @@ package com.lovemarker;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class LovemarkerApplication {
 

--- a/src/main/java/com/lovemarker/LovemarkerApplication.java
+++ b/src/main/java/com/lovemarker/LovemarkerApplication.java
@@ -2,7 +2,9 @@ package com.lovemarker;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class LovemarkerApplication {
 

--- a/src/main/java/com/lovemarker/domain/couple/controller/CoupleController.java
+++ b/src/main/java/com/lovemarker/domain/couple/controller/CoupleController.java
@@ -1,0 +1,31 @@
+package com.lovemarker.domain.couple.controller;
+
+import com.lovemarker.domain.couple.dto.request.CreateInvitationCodeRequest;
+import com.lovemarker.domain.couple.dto.response.CreateInvitationCodeResponse;
+import com.lovemarker.domain.couple.service.CoupleService;
+import com.lovemarker.global.constant.SuccessCode;
+import com.lovemarker.global.dto.ApiResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/couple")
+@RequiredArgsConstructor
+public class CoupleController {
+
+    private final CoupleService coupleService;
+
+    @PostMapping
+    public ApiResponseDto<CreateInvitationCodeResponse> createInvitationCode(
+        @RequestHeader Long userId,
+        @Valid @RequestBody final CreateInvitationCodeRequest createInvitationCodeRequest
+    ) {
+        return ApiResponseDto.success(SuccessCode.CREATE_INVITATION_CODE_SUCCESS,
+            coupleService.createInvitationCode(userId, createInvitationCodeRequest.anniversary()));
+    }
+}

--- a/src/main/java/com/lovemarker/domain/couple/dto/request/CreateInvitationCodeRequest.java
+++ b/src/main/java/com/lovemarker/domain/couple/dto/request/CreateInvitationCodeRequest.java
@@ -1,0 +1,10 @@
+package com.lovemarker.domain.couple.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+public record CreateInvitationCodeRequest(
+    @NotNull(message = "기념일은 필수 입력 항목입니다.") LocalDate anniversary
+) {
+
+}

--- a/src/main/java/com/lovemarker/domain/couple/dto/response/CreateInvitationCodeResponse.java
+++ b/src/main/java/com/lovemarker/domain/couple/dto/response/CreateInvitationCodeResponse.java
@@ -5,7 +5,7 @@ import com.lovemarker.domain.couple.Couple;
 public record CreateInvitationCodeResponse(
     String invitationCode
 ) {
-    public static CreateInvitationCodeResponse of(Couple couple) {
+    public static CreateInvitationCodeResponse from(Couple couple) {
         return new CreateInvitationCodeResponse(couple.getInviteCode());
     }
 }

--- a/src/main/java/com/lovemarker/domain/couple/dto/response/CreateInvitationCodeResponse.java
+++ b/src/main/java/com/lovemarker/domain/couple/dto/response/CreateInvitationCodeResponse.java
@@ -1,0 +1,11 @@
+package com.lovemarker.domain.couple.dto.response;
+
+import com.lovemarker.domain.couple.Couple;
+
+public record CreateInvitationCodeResponse(
+    String invitationCode
+) {
+    public static CreateInvitationCodeResponse of(Couple couple) {
+        return new CreateInvitationCodeResponse(couple.getInviteCode());
+    }
+}

--- a/src/main/java/com/lovemarker/domain/couple/repository/CoupleRepository.java
+++ b/src/main/java/com/lovemarker/domain/couple/repository/CoupleRepository.java
@@ -1,0 +1,8 @@
+package com.lovemarker.domain.couple.repository;
+
+import com.lovemarker.domain.couple.Couple;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CoupleRepository extends JpaRepository<Couple, Long> {
+
+}

--- a/src/main/java/com/lovemarker/domain/couple/service/CoupleService.java
+++ b/src/main/java/com/lovemarker/domain/couple/service/CoupleService.java
@@ -11,6 +11,7 @@ import com.lovemarker.global.exception.NotFoundException;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -20,11 +21,13 @@ public class CoupleService {
     private final UserRepository userRepository;
     private final InviteCodeStrategy inviteCodeStrategy;
 
+    @Transactional
     public CreateInvitationCodeResponse createInvitationCode(Long userId, LocalDate anniversary) {
         User user = getUserByUserId(userId);
         Couple couple = new Couple(anniversary, getNewInvitationCode());
         user.connectCouple(couple);
-        return CreateInvitationCodeResponse.of(coupleRepository.save(couple));
+        coupleRepository.save(couple);
+        return CreateInvitationCodeResponse.from(couple);
     }
 
     private User getUserByUserId(Long userId) {

--- a/src/main/java/com/lovemarker/domain/couple/service/CoupleService.java
+++ b/src/main/java/com/lovemarker/domain/couple/service/CoupleService.java
@@ -1,0 +1,38 @@
+package com.lovemarker.domain.couple.service;
+
+import com.lovemarker.domain.couple.Couple;
+import com.lovemarker.domain.couple.InviteCodeStrategy;
+import com.lovemarker.domain.couple.dto.response.CreateInvitationCodeResponse;
+import com.lovemarker.domain.couple.repository.CoupleRepository;
+import com.lovemarker.domain.user.User;
+import com.lovemarker.domain.user.repository.UserRepository;
+import com.lovemarker.global.constant.ErrorCode;
+import com.lovemarker.global.exception.NotFoundException;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CoupleService {
+
+    private final CoupleRepository coupleRepository;
+    private final UserRepository userRepository;
+    private final InviteCodeStrategy inviteCodeStrategy;
+
+    public CreateInvitationCodeResponse createInvitationCode(Long userId, LocalDate anniversary) {
+        User user = getUserByUserId(userId);
+        Couple couple = new Couple(anniversary, getNewInvitationCode());
+        user.connectCouple(couple);
+        return CreateInvitationCodeResponse.of(coupleRepository.save(couple));
+    }
+
+    private User getUserByUserId(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_EXCEPTION, "존재하지 않는 유저입니다."));
+    }
+
+    private String getNewInvitationCode() {
+        return inviteCodeStrategy.generate();
+    }
+}

--- a/src/main/java/com/lovemarker/domain/user/User.java
+++ b/src/main/java/com/lovemarker/domain/user/User.java
@@ -5,6 +5,8 @@ import com.lovemarker.domain.couple.Couple;
 import com.lovemarker.domain.user.vo.SocialToken;
 import com.lovemarker.domain.user.vo.SocialType;
 import com.lovemarker.domain.user.vo.UserNickname;
+import com.lovemarker.global.constant.ErrorCode;
+import com.lovemarker.global.exception.BadRequestException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -50,7 +52,10 @@ public class User extends BaseTimeEntity {
         this.socialToken = new SocialToken(socialToken);
     }
 
-    public void makeCouple(Couple couple) {
+    public void connectCouple(Couple couple) {
+        if (this.couple != null) {
+            throw new BadRequestException(ErrorCode.REQUEST_VALIDATION_EXCEPTION, "커플 정보가 존재합니다.");
+        }
         this.couple = couple;
     }
 

--- a/src/main/java/com/lovemarker/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/lovemarker/domain/user/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.lovemarker.domain.user.repository;
+
+import com.lovemarker.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/src/main/java/com/lovemarker/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/lovemarker/global/config/JpaAuditingConfig.java
@@ -1,0 +1,10 @@
+package com.lovemarker.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+
+}

--- a/src/main/java/com/lovemarker/global/constant/ErrorCode.java
+++ b/src/main/java/com/lovemarker/global/constant/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     // 400
     REQUEST_VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     MISSING_REQUIRED_INFO_EXCEPTION(HttpStatus.BAD_REQUEST, "필수 입력 항목이 입력되지 않았습니다."),
+    MISSING_REQUIRED_HEADER_EXCEPTION(HttpStatus.BAD_REQUEST, "필수 입력 헤더 정보가 입력되지 않았습니다."),
 
     // 404
     NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "존재하지 않는 리소스입니다."),

--- a/src/main/java/com/lovemarker/global/constant/SuccessCode.java
+++ b/src/main/java/com/lovemarker/global/constant/SuccessCode.java
@@ -10,9 +10,10 @@ import org.springframework.http.HttpStatus;
 public enum SuccessCode {
 
     // 200
-    LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공했습니다.");
+    LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공했습니다."),
 
     // 201
+    CREATE_INVITATION_CODE_SUCCESS(HttpStatus.CREATED, "초대 코드 생성을 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/lovemarker/global/dto/ApiResponseDto.java
+++ b/src/main/java/com/lovemarker/global/dto/ApiResponseDto.java
@@ -17,20 +17,20 @@ public class ApiResponseDto<T> {
     private final String message;
     private T data;
 
-    public static ApiResponseDto success(SuccessCode successStatus) {
-        return new ApiResponseDto<>(successStatus.getHttpStatusCode(), true, successStatus.getMessage());
+    public static ApiResponseDto success(SuccessCode successCode) {
+        return new ApiResponseDto<>(successCode.getHttpStatusCode(), true, successCode.getMessage());
     }
 
-    public static <T> ApiResponseDto<T> success(SuccessCode successStatus, T data) {
-        return new ApiResponseDto<T>(successStatus.getHttpStatusCode(), true, successStatus.getMessage(), data);
+    public static <T> ApiResponseDto<T> success(SuccessCode successCode, T data) {
+        return new ApiResponseDto<T>(successCode.getHttpStatusCode(), true, successCode.getMessage(), data);
     }
 
-    public static ApiResponseDto error(ErrorCode errorStatus) {
-        return new ApiResponseDto<>(errorStatus.getHttpStatusCode(), false, errorStatus.getMessage());
+    public static ApiResponseDto error(ErrorCode errorCode) {
+        return new ApiResponseDto<>(errorCode.getHttpStatusCode(), false, errorCode.getMessage());
     }
 
-    public static ApiResponseDto error(ErrorCode errorStatus, String message) {
-        return new ApiResponseDto<>(errorStatus.getHttpStatusCode(), false, message);
+    public static ApiResponseDto error(ErrorCode errorCode, String message) {
+        return new ApiResponseDto<>(errorCode.getHttpStatusCode(), false, message);
     }
 }
 

--- a/src/main/java/com/lovemarker/global/exception/BasicException.java
+++ b/src/main/java/com/lovemarker/global/exception/BasicException.java
@@ -11,7 +11,11 @@ public abstract class BasicException extends RuntimeException {
         this.errorCode = errorCode;
     }
 
-    public int getErrorCode() {
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+    public int getErrorStatusCode() {
         return errorCode.getHttpStatusCode();
     }
 }

--- a/src/main/java/com/lovemarker/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/lovemarker/global/exception/GlobalExceptionHandler.java
@@ -3,7 +3,12 @@ package com.lovemarker.global.exception;
 import com.lovemarker.global.constant.ErrorCode;
 import com.lovemarker.global.dto.ApiResponseDto;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Objects;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -11,9 +16,37 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    /**
+     * 400 BAD_REQUEST
+     */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ApiResponseDto handleMethodArgumentNotValidException(final MethodArgumentNotValidException e) {
+        FieldError fieldError = Objects.requireNonNull(e.getFieldError());
+        return ApiResponseDto.error(ErrorCode.MISSING_REQUIRED_INFO_EXCEPTION, String.format("%s. (%s)", fieldError.getDefaultMessage(), fieldError.getField()));
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    protected ApiResponseDto handleMissingRequestHeaderException(final MissingRequestHeaderException e) {
+        return ApiResponseDto.error(ErrorCode.MISSING_REQUIRED_HEADER_EXCEPTION, String.format("%s. (%s)", ErrorCode.MISSING_REQUIRED_HEADER_EXCEPTION.getMessage(), e.getHeaderName()));
+    }
+
+    /**
+     * 500 SERVER_ERROR
+     */
     @ExceptionHandler(Exception.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     protected ApiResponseDto<Object> handleException(final Exception error, final HttpServletRequest request) {
         return ApiResponseDto.error(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * CUSTOM_ERROR
+     */
+    @ExceptionHandler(BasicException.class)
+    protected ResponseEntity<ApiResponseDto> handleBasicException(BasicException e) {
+        return ResponseEntity.status(e.getErrorStatusCode())
+            .body(ApiResponseDto.error(e.getErrorCode(), e.getMessage()));
     }
 }

--- a/src/test/java/com/lovemarker/base/BaseControllerTest.java
+++ b/src/test/java/com/lovemarker/base/BaseControllerTest.java
@@ -4,12 +4,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.lovemarker.base.config.RestDocsConfig;
+import com.lovemarker.domain.couple.service.CoupleService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -25,10 +30,21 @@ public abstract class BaseControllerTest {
     @Autowired
     protected ObjectMapper objectMapper;
 
+    @Autowired
+    protected RestDocumentationResultHandler restDocs;
+
+    @MockBean
+    protected CoupleService coupleService;
+
     @BeforeEach
-    void setUp(WebApplicationContext context) {
-        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+    void setUp(
+        WebApplicationContext applicationContext,
+        RestDocumentationContextProvider documentationContextProvider) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(applicationContext)
             .alwaysDo(print())
+            .alwaysDo(restDocs)
+            .apply(
+                MockMvcRestDocumentation.documentationConfiguration(documentationContextProvider))
             .addFilter(new CharacterEncodingFilter("UTF-8", true))
             .build();
     }

--- a/src/test/java/com/lovemarker/domain/couple/controller/CoupleControllerTest.java
+++ b/src/test/java/com/lovemarker/domain/couple/controller/CoupleControllerTest.java
@@ -1,0 +1,60 @@
+package com.lovemarker.domain.couple.controller;
+
+import static javax.management.openmbean.SimpleType.BOOLEAN;
+import static javax.management.openmbean.SimpleType.STRING;
+import static javax.swing.text.html.parser.DTDConstants.NUMBER;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+import com.lovemarker.base.BaseControllerTest;
+import com.lovemarker.domain.couple.dto.request.CreateInvitationCodeRequest;
+import com.lovemarker.domain.couple.dto.response.CreateInvitationCodeResponse;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+class CoupleControllerTest extends BaseControllerTest {
+
+    @Test
+    @DisplayName("성공: 초대 코드 생성 api 호출 시")
+    void createInvitationCode() throws Exception {
+        //given
+        Long userId = 1L;
+        CreateInvitationCodeRequest request = new CreateInvitationCodeRequest(LocalDate.parse("2023-02-15"));
+        CreateInvitationCodeResponse response = new CreateInvitationCodeResponse("test_code");
+
+        given(coupleService.createInvitationCode(anyLong(), any())).willReturn(response);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(post("/api/couple")
+            .header("userId", userId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)));
+
+        //then
+        resultActions
+            .andDo(restDocs.document(
+                requestHeaders(
+                    headerWithName("userId").description("유저 아이디")
+                ),
+                requestFields(
+                    fieldWithPath("anniversary").type(STRING).description("기념일")
+                ),
+                responseFields(
+                    fieldWithPath("status").type(NUMBER).description("상태 코드"),
+                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                    fieldWithPath("message").type(STRING).description("메시지"),
+                    fieldWithPath("data.invitationCode").type(STRING).description("초대 코드")
+                )
+            ));
+    }
+}

--- a/src/test/java/com/lovemarker/domain/couple/service/CoupleServiceTest.java
+++ b/src/test/java/com/lovemarker/domain/couple/service/CoupleServiceTest.java
@@ -1,0 +1,73 @@
+package com.lovemarker.domain.couple.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.lovemarker.domain.couple.InviteCodeStrategy;
+import com.lovemarker.domain.couple.repository.CoupleRepository;
+import com.lovemarker.domain.user.User;
+import com.lovemarker.domain.user.fixture.UserFixture;
+import com.lovemarker.domain.user.repository.UserRepository;
+import com.lovemarker.global.exception.NotFoundException;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CoupleServiceTest {
+
+    @InjectMocks
+    CoupleService coupleService;
+
+    @Mock
+    CoupleRepository coupleRepository;
+
+    @Mock
+    InviteCodeStrategy inviteCodeStrategy;
+
+    @Mock
+    UserRepository userRepository;
+
+    @Nested
+    @DisplayName("createInvitationCode 메서드 실행 시")
+    class CreateInvitationCodeTest {
+
+        User user = UserFixture.user();
+        LocalDate anniversary = LocalDate.parse("2023-02-15");
+
+        @Test
+        @DisplayName("성공")
+        void createInvitationCode() {
+            //given
+            given(userRepository.findById(anyLong())).willReturn(Optional.ofNullable(user));
+            given(inviteCodeStrategy.generate()).willReturn("INVITE_CODE");
+
+            //when
+            coupleService.createInvitationCode(1L, anniversary);
+
+            //then
+            then(coupleRepository).should().save(any());
+        }
+
+        @Test
+        @DisplayName("예외(NotFoundException): 존재하지 않는 유저")
+        void exceptionWhenUserNotFound() {
+            //given
+            //when
+            Exception exception = catchException(() -> coupleService.createInvitationCode(1L, anniversary));
+
+            //then
+            assertThat(exception).isInstanceOf(NotFoundException.class);
+        }
+    }
+}

--- a/src/test/java/com/lovemarker/domain/memory/MemoryTest.java
+++ b/src/test/java/com/lovemarker/domain/memory/MemoryTest.java
@@ -32,7 +32,7 @@ class MemoryTest {
         @DisplayName("성공")
         void newMemory() {
             //given
-            user.makeCouple(couple);
+            user.connectCouple(couple);
 
             //when
             Memory memory = new Memory(title, content, addressInfo.getAddress(), addressInfo.getPosition(), user, urls);

--- a/src/test/java/com/lovemarker/domain/user/UserTest.java
+++ b/src/test/java/com/lovemarker/domain/user/UserTest.java
@@ -60,7 +60,7 @@ class UserTest {
         void makeCouple() {
             //given
             //when
-            user.makeCouple(couple);
+            user.connectCouple(couple);
 
             //then
             assertThat(user.getCouple()).isEqualTo(couple);

--- a/src/test/java/com/lovemarker/domain/user/UserTest.java
+++ b/src/test/java/com/lovemarker/domain/user/UserTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.BDDAssertions.catchException;
 import com.lovemarker.domain.couple.Couple;
 import com.lovemarker.domain.couple.fixture.CoupleFixture;
 import com.lovemarker.domain.user.fixture.UserFixture;
+import com.lovemarker.global.exception.BadRequestException;
 import com.lovemarker.global.exception.NotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -50,7 +51,7 @@ class UserTest {
 
     @Nested
     @DisplayName("Couple 등록 시")
-    class makeCoupleTest {
+    class connectCoupleTest {
 
         User user = UserFixture.user();
         Couple couple = CoupleFixture.couple();
@@ -64,6 +65,19 @@ class UserTest {
 
             //then
             assertThat(user.getCouple()).isEqualTo(couple);
+        }
+
+        @Test
+        @DisplayName("예외(BadRequestException): 이미 커플 정보가 존재하는 경우")
+        void exceptionWhenCoupleIsNotNull() {
+            //given
+            user.connectCouple(couple);
+
+            //when
+            Exception exception = catchException(() -> user.connectCouple(couple));
+
+            //then
+            assertThat(exception).isInstanceOf(BadRequestException.class);
         }
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
커플 생성 API

### 📝 작업 요약
- 초대 코드 생성 service, controller, requestDto, responseDto 작성
- UserRepository, CoupleRepository 생성
- 커플 연결 시 유저의 커플 정보 null인 확인하는 코드 추가
- 테스트 코드 작성

### 💡 관련 이슈
- close #8 
