### PR TITLE
feat: 커플 수락 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation group: 'org.postgresql', name: 'postgresql', version: '42.2.27'
 	runtimeOnly 'org.postgresql:postgresql'
+	runtimeOnly 'com.h2database:h2'
+
 	// hibernate-spatial
 	implementation 'org.hibernate:hibernate-spatial:6.1.7.Final'
 

--- a/src/main/java/com/lovemarker/domain/couple/Couple.java
+++ b/src/main/java/com/lovemarker/domain/couple/Couple.java
@@ -24,7 +24,7 @@ public class Couple extends BaseTimeEntity {
     @Column(name = "anniversary", nullable = false)
     private LocalDate anniversary;
 
-    @Column(name = "invite_code", nullable = false)
+    @Column(name = "invite_code", nullable = false, unique = true)
     private String inviteCode;
 
     public Couple(LocalDate anniversary, String inviteCode) {

--- a/src/main/java/com/lovemarker/domain/couple/controller/CoupleController.java
+++ b/src/main/java/com/lovemarker/domain/couple/controller/CoupleController.java
@@ -1,6 +1,7 @@
 package com.lovemarker.domain.couple.controller;
 
 import com.lovemarker.domain.couple.dto.request.CreateInvitationCodeRequest;
+import com.lovemarker.domain.couple.dto.request.JoinCoupleRequest;
 import com.lovemarker.domain.couple.dto.response.CreateInvitationCodeResponse;
 import com.lovemarker.domain.couple.service.CoupleService;
 import com.lovemarker.global.constant.SuccessCode;
@@ -27,5 +28,14 @@ public class CoupleController {
     ) {
         return ApiResponseDto.success(SuccessCode.CREATE_INVITATION_CODE_SUCCESS,
             coupleService.createInvitationCode(userId, createInvitationCodeRequest.anniversary()));
+    }
+
+    @PostMapping("/join")
+    public ApiResponseDto joinCouple(
+        @RequestHeader Long userId,
+        @Valid @RequestBody final JoinCoupleRequest joinCoupleRequest
+    ) {
+        coupleService.joinCouple(userId, joinCoupleRequest.invitationCode());
+        return ApiResponseDto.success(SuccessCode.JOIN_COUPLE_SUCCESS);
     }
 }

--- a/src/main/java/com/lovemarker/domain/couple/dto/request/JoinCoupleRequest.java
+++ b/src/main/java/com/lovemarker/domain/couple/dto/request/JoinCoupleRequest.java
@@ -1,0 +1,9 @@
+package com.lovemarker.domain.couple.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record JoinCoupleRequest(
+    @NotBlank(message = "초대 코드는 필수 입력 항목입니다.") String invitationCode
+) {
+
+}

--- a/src/main/java/com/lovemarker/domain/couple/repository/CoupleRepository.java
+++ b/src/main/java/com/lovemarker/domain/couple/repository/CoupleRepository.java
@@ -1,8 +1,10 @@
 package com.lovemarker.domain.couple.repository;
 
 import com.lovemarker.domain.couple.Couple;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CoupleRepository extends JpaRepository<Couple, Long> {
 
+    Optional<Couple> findByInviteCode(String inviteCode);
 }

--- a/src/main/java/com/lovemarker/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/lovemarker/domain/user/repository/UserRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
+    long countByCouple_CoupleId(Long coupleId);
 }

--- a/src/main/java/com/lovemarker/global/constant/SuccessCode.java
+++ b/src/main/java/com/lovemarker/global/constant/SuccessCode.java
@@ -13,7 +13,8 @@ public enum SuccessCode {
     LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공했습니다."),
 
     // 201
-    CREATE_INVITATION_CODE_SUCCESS(HttpStatus.CREATED, "초대 코드 생성을 성공했습니다.");
+    CREATE_INVITATION_CODE_SUCCESS(HttpStatus.CREATED, "초대 코드 생성을 성공했습니다."),
+    JOIN_COUPLE_SUCCESS(HttpStatus.CREATED, "커플 연결을 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/test/java/com/lovemarker/base/BaseRepositoryTest.java
+++ b/src/test/java/com/lovemarker/base/BaseRepositoryTest.java
@@ -1,5 +1,7 @@
 package com.lovemarker.base;
 
+import com.lovemarker.domain.couple.repository.CoupleRepository;
+import com.lovemarker.domain.user.repository.UserRepository;
 import jakarta.persistence.EntityManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -9,4 +11,10 @@ public abstract class BaseRepositoryTest {
 
     @Autowired
     protected EntityManager entityManager;
+
+    @Autowired
+    protected UserRepository userRepository;
+
+    @Autowired
+    protected CoupleRepository coupleRepository;
 }

--- a/src/test/java/com/lovemarker/domain/couple/controller/CoupleControllerTest.java
+++ b/src/test/java/com/lovemarker/domain/couple/controller/CoupleControllerTest.java
@@ -15,6 +15,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 
 import com.lovemarker.base.BaseControllerTest;
 import com.lovemarker.domain.couple.dto.request.CreateInvitationCodeRequest;
+import com.lovemarker.domain.couple.dto.request.JoinCoupleRequest;
 import com.lovemarker.domain.couple.dto.response.CreateInvitationCodeResponse;
 import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
@@ -54,6 +55,38 @@ class CoupleControllerTest extends BaseControllerTest {
                     fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
                     fieldWithPath("message").type(STRING).description("메시지"),
                     fieldWithPath("data.invitationCode").type(STRING).description("초대 코드")
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("성공: 커플 수락 api 호출 시")
+    void joinCouple() throws Exception {
+        //given
+        Long userId = 1L;
+        String invitationCode = "test_code";
+        JoinCoupleRequest request = new JoinCoupleRequest(invitationCode);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(post("/api/couple/join")
+            .header("userId", userId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)));
+
+        //then
+        resultActions
+            .andDo(restDocs.document(
+                requestHeaders(
+                    headerWithName("userId").description("유저 아이디")
+                ),
+                requestFields(
+                    fieldWithPath("invitationCode").type(STRING).description("초대 코드")
+                ),
+                responseFields(
+                    fieldWithPath("status").type(NUMBER).description("상태 코드"),
+                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                    fieldWithPath("message").type(STRING).description("메시지"),
+                    fieldWithPath("data").ignored()
                 )
             ));
     }

--- a/src/test/java/com/lovemarker/domain/couple/repository/CoupleRepositoryTest.java
+++ b/src/test/java/com/lovemarker/domain/couple/repository/CoupleRepositoryTest.java
@@ -1,0 +1,33 @@
+package com.lovemarker.domain.couple.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.lovemarker.base.BaseRepositoryTest;
+import com.lovemarker.domain.couple.Couple;
+import com.lovemarker.domain.couple.fixture.CoupleFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class CoupleRepositoryTest extends BaseRepositoryTest {
+
+    @Nested
+    @DisplayName("findByInviteCode 메서드 실행 시")
+    class FindByInviteCodeTest {
+
+        @Test
+        @DisplayName("성공")
+        void findByInviteCode() {
+            //given
+            Couple couple = CoupleFixture.couple();
+            coupleRepository.save(couple);
+            String expected = couple.getInviteCode();
+
+            //when
+            String result = coupleRepository.findByInviteCode(expected).get().getInviteCode();
+
+            //then
+            assertThat(result).isEqualTo(expected);
+        }
+    }
+}

--- a/src/test/java/com/lovemarker/domain/couple/service/CoupleServiceTest.java
+++ b/src/test/java/com/lovemarker/domain/couple/service/CoupleServiceTest.java
@@ -7,11 +7,14 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
+import com.lovemarker.domain.couple.Couple;
 import com.lovemarker.domain.couple.InviteCodeStrategy;
+import com.lovemarker.domain.couple.fixture.CoupleFixture;
 import com.lovemarker.domain.couple.repository.CoupleRepository;
 import com.lovemarker.domain.user.User;
 import com.lovemarker.domain.user.fixture.UserFixture;
 import com.lovemarker.domain.user.repository.UserRepository;
+import com.lovemarker.global.exception.BadRequestException;
 import com.lovemarker.global.exception.NotFoundException;
 import java.time.LocalDate;
 import java.util.Optional;
@@ -67,6 +70,68 @@ class CoupleServiceTest {
 
             //then
             assertThat(exception).isInstanceOf(NotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("joinCouple 메서드 실행 시")
+    class JoinCoupleTest {
+
+        User user = UserFixture.user();
+        Couple couple = CoupleFixture.couple();
+
+        @Test
+        @DisplayName("성공")
+        void joinCouple() {
+            //given
+            given(userRepository.findById(anyLong())).willReturn(Optional.ofNullable(user));
+            given(coupleRepository.findByInviteCode(any())).willReturn(Optional.ofNullable(couple));
+            given(userRepository.countByCouple_CoupleId(any())).willReturn(1L);
+
+            //when
+            coupleService.joinCouple(1L, "inviteCode");
+
+            //then
+            assertThat(user.getCouple()).isEqualTo(couple);
+        }
+
+        @Test
+        @DisplayName("예외(NotFoundException): 존재하지 않는 유저")
+        void exceptionWhenUserNotFound() {
+            //given
+            //when
+            Exception exception = catchException(() -> coupleService.joinCouple(1L, "inviteCode"));
+
+            //then
+            assertThat(exception).isInstanceOf(NotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("예외(NotFoundException): 존재하지 않는 커플")
+        void exceptionWhenCoupleNotFound() {
+            //given
+            given(userRepository.findById(anyLong())).willReturn(Optional.ofNullable(user));
+
+            //when
+            Exception exception = catchException(() -> coupleService.joinCouple(1L, "inviteCode"));
+
+            //then
+            assertThat(exception).isInstanceOf(NotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("예외(BadRequestException): 이미 연결이 완료된 커플")
+        void exceptionWhenCoupleAlreadyConnected() {
+            //given
+            given(userRepository.findById(anyLong())).willReturn(Optional.ofNullable(user));
+            given(coupleRepository.findByInviteCode(any())).willReturn(Optional.ofNullable(couple));
+            given(userRepository.countByCouple_CoupleId(any())).willReturn(2L);
+
+            //when
+            Exception exception = catchException(() -> coupleService.joinCouple(1L, "inviteCode"));
+
+            //then
+            assertThat(exception).isInstanceOf(BadRequestException.class);
         }
     }
 }

--- a/src/test/java/com/lovemarker/domain/couple/service/CoupleServiceTest.java
+++ b/src/test/java/com/lovemarker/domain/couple/service/CoupleServiceTest.java
@@ -50,7 +50,6 @@ class CoupleServiceTest {
         void createInvitationCode() {
             //given
             given(userRepository.findById(anyLong())).willReturn(Optional.ofNullable(user));
-            given(inviteCodeStrategy.generate()).willReturn("INVITE_CODE");
 
             //when
             coupleService.createInvitationCode(1L, anniversary);

--- a/src/test/java/com/lovemarker/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/lovemarker/domain/user/repository/UserRepositoryTest.java
@@ -1,0 +1,39 @@
+package com.lovemarker.domain.user.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.lovemarker.base.BaseRepositoryTest;
+import com.lovemarker.domain.couple.Couple;
+import com.lovemarker.domain.couple.fixture.CoupleFixture;
+import com.lovemarker.domain.user.User;
+import com.lovemarker.domain.user.fixture.UserFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class UserRepositoryTest extends BaseRepositoryTest {
+
+    @Nested
+    @DisplayName("countByCouple_CoupleId 메서드 실행 시")
+    class CountByCouple_CoupleIdTest {
+
+        @Test
+        @DisplayName("성공")
+        void countByCouple_CoupleId() {
+            // given
+            User user = UserFixture.user();
+            Couple couple = CoupleFixture.couple();
+            user.connectCouple(couple);
+            userRepository.save(user);
+            coupleRepository.save(couple);
+            Long expected = 1L;
+
+            //when
+            Long result = userRepository.countByCouple_CoupleId(couple.getCoupleId());
+
+            //then
+            assertThat(result).isEqualTo(expected);
+        }
+    }
+
+}


### PR DESCRIPTION
### ⛏ 작업 사항
커플 수락 API

### 📝 작업 요약
- 커플 수락 service, controller, repository, requestDto 작성
- 커플 연결 시 해당 커플의 인원이 초과하는지 검사
- 테스트 코드 작성

### 💡 관련 이슈
- close #9 
