### PR TITLE
feat: 닉네임 변경 API

### DIFF
--- a/src/main/java/com/lovemarker/domain/user/User.java
+++ b/src/main/java/com/lovemarker/domain/user/User.java
@@ -59,6 +59,10 @@ public class User extends BaseTimeEntity {
         this.couple = couple;
     }
 
+    public void updateUserNickname(String nickname) {
+        this.nickname = new UserNickname(nickname);
+    }
+
     public Long getUserId() {
         return userId;
     }

--- a/src/main/java/com/lovemarker/domain/user/controller/UserController.java
+++ b/src/main/java/com/lovemarker/domain/user/controller/UserController.java
@@ -1,0 +1,30 @@
+package com.lovemarker.domain.user.controller;
+
+import com.lovemarker.domain.user.dto.request.UpdateUserNicknameRequest;
+import com.lovemarker.domain.user.service.UserService;
+import com.lovemarker.global.config.resolver.UserId;
+import com.lovemarker.global.constant.SuccessCode;
+import com.lovemarker.global.dto.ApiResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PatchMapping("/nickname")
+    public ApiResponseDto updateUserNickname(
+        @UserId Long userId,
+        @Valid @RequestBody final UpdateUserNicknameRequest updateUserNicknameRequest
+    ) {
+        userService.updateUserNickname(userId, updateUserNicknameRequest.nickname());
+        return ApiResponseDto.success(SuccessCode.UPDATE_USER_NICKNAME_SUCCESS);
+    }
+}

--- a/src/main/java/com/lovemarker/domain/user/dto/request/UpdateUserNicknameRequest.java
+++ b/src/main/java/com/lovemarker/domain/user/dto/request/UpdateUserNicknameRequest.java
@@ -1,0 +1,9 @@
+package com.lovemarker.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateUserNicknameRequest(
+    @NotBlank(message = "닉네임은 필수 입력 항목입니다.") String nickname
+) {
+
+}

--- a/src/main/java/com/lovemarker/domain/user/exception/UserNicknameDuplicateException.java
+++ b/src/main/java/com/lovemarker/domain/user/exception/UserNicknameDuplicateException.java
@@ -1,0 +1,11 @@
+package com.lovemarker.domain.user.exception;
+
+import com.lovemarker.global.constant.ErrorCode;
+import com.lovemarker.global.exception.BasicException;
+
+public class UserNicknameDuplicateException extends BasicException {
+
+    public UserNicknameDuplicateException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/com/lovemarker/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/lovemarker/domain/user/repository/UserRepository.java
@@ -10,5 +10,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     long countByCouple_CoupleId(Long coupleId);
     Optional<User> findBySocialToken_SocialTokenAndProvider(String socialToken, SocialType provider);
     boolean existsBySocialToken_SocialTokenAndProvider(String socialToken, SocialType provider);
+    boolean existsByNickname_Nickname(String nickname);
 
 }

--- a/src/main/java/com/lovemarker/domain/user/service/UserService.java
+++ b/src/main/java/com/lovemarker/domain/user/service/UserService.java
@@ -1,0 +1,35 @@
+package com.lovemarker.domain.user.service;
+
+import com.lovemarker.domain.user.User;
+import com.lovemarker.domain.user.exception.UserNicknameDuplicateException;
+import com.lovemarker.domain.user.repository.UserRepository;
+import com.lovemarker.global.constant.ErrorCode;
+import com.lovemarker.global.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void updateUserNickname(Long userId, String nickname) {
+        checkDuplicatedNickname(nickname);
+        getUserByUserId(userId).updateUserNickname(nickname);
+    }
+
+    private User getUserByUserId(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_EXCEPTION, "존재하지 않는 유저입니다."));
+    }
+
+    private void checkDuplicatedNickname(String nickname) {
+        if (userRepository.existsByNickname_Nickname(nickname)) {
+            throw new UserNicknameDuplicateException(ErrorCode.DUPLICATE_NICKNAME_EXCEPTION,
+                ErrorCode.DUPLICATE_NICKNAME_EXCEPTION.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/lovemarker/domain/user/service/UserService.java
+++ b/src/main/java/com/lovemarker/domain/user/service/UserService.java
@@ -2,9 +2,9 @@ package com.lovemarker.domain.user.service;
 
 import com.lovemarker.domain.user.User;
 import com.lovemarker.domain.user.exception.UserNicknameDuplicateException;
+import com.lovemarker.domain.user.exception.UserNotFoundException;
 import com.lovemarker.domain.user.repository.UserRepository;
 import com.lovemarker.global.constant.ErrorCode;
-import com.lovemarker.global.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +23,7 @@ public class UserService {
 
     private User getUserByUserId(Long userId) {
         return userRepository.findById(userId)
-            .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_EXCEPTION, "존재하지 않는 유저입니다."));
+            .orElseThrow(() -> new UserNotFoundException(ErrorCode.NOT_FOUND_EXCEPTION, "존재하지 않는 유저입니다."));
     }
 
     private void checkDuplicatedNickname(String nickname) {

--- a/src/main/java/com/lovemarker/domain/user/vo/UserNickname.java
+++ b/src/main/java/com/lovemarker/domain/user/vo/UserNickname.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserNickname {
 
-    private static final int MAX_NICKNAME_LENGTH = 10;
+    private static final int MAX_NICKNAME_LENGTH = 8;
 
     @Column(name = "nickname", nullable = false)
     private String nickname;
@@ -33,7 +33,7 @@ public class UserNickname {
 
     private void validateNicknameLength(String nickname) {
         if (nickname.length() > MAX_NICKNAME_LENGTH) {
-            throw new BadRequestException(ErrorCode.REQUEST_VALIDATION_EXCEPTION, "닉네임은 최대 10자입니다.");
+            throw new BadRequestException(ErrorCode.REQUEST_VALIDATION_EXCEPTION, "닉네임은 최대 8자입니다.");
         }
     }
 }

--- a/src/main/java/com/lovemarker/global/constant/ErrorCode.java
+++ b/src/main/java/com/lovemarker/global/constant/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     MISSING_REQUIRED_INFO_EXCEPTION(HttpStatus.BAD_REQUEST, "필수 입력 항목이 입력되지 않았습니다."),
     MISSING_REQUIRED_HEADER_EXCEPTION(HttpStatus.BAD_REQUEST, "필수 입력 헤더 정보가 입력되지 않았습니다."),
     NULL_ACCESS_TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST, "토큰 값이 없습니다."),
+    DUPLICATE_NICKNAME_EXCEPTION(HttpStatus.BAD_REQUEST, "중복된 닉네임입니다."),
 
     // 401
     ACCESS_TOKEN_TIME_EXPIRED_EXCEPTION(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),

--- a/src/main/java/com/lovemarker/global/constant/SuccessCode.java
+++ b/src/main/java/com/lovemarker/global/constant/SuccessCode.java
@@ -11,6 +11,7 @@ public enum SuccessCode {
 
     // 200
     LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공했습니다."),
+    UPDATE_USER_NICKNAME_SUCCESS(HttpStatus.OK, "닉네임 변경에 성공했습니다."),
 
     // 201
     CREATE_INVITATION_CODE_SUCCESS(HttpStatus.CREATED, "초대 코드 생성을 성공했습니다."),

--- a/src/test/java/com/lovemarker/base/BaseControllerTest.java
+++ b/src/test/java/com/lovemarker/base/BaseControllerTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.lovemarker.base.config.RestDocsConfig;
 import com.lovemarker.domain.auth.service.AuthService;
 import com.lovemarker.domain.couple.service.CoupleService;
+import com.lovemarker.domain.user.service.UserService;
 import com.lovemarker.global.config.resolver.UserIdResolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,6 +41,9 @@ public abstract class BaseControllerTest {
 
     @MockBean
     protected AuthService authService;
+
+    @MockBean
+    protected UserService userService;
 
     @MockBean
     protected UserIdResolver userIdResolver;

--- a/src/test/java/com/lovemarker/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/lovemarker/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,53 @@
+package com.lovemarker.domain.user.controller;
+
+import static javax.management.openmbean.SimpleType.BOOLEAN;
+import static javax.management.openmbean.SimpleType.STRING;
+import static javax.swing.text.html.parser.DTDConstants.NUMBER;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+
+import com.lovemarker.base.BaseControllerTest;
+import com.lovemarker.domain.user.dto.request.UpdateUserNicknameRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+class UserControllerTest extends BaseControllerTest {
+
+    @Test
+    @DisplayName("성공: 유저 닉네임 변경 api 호출 시")
+    void updateUserNickname() throws Exception {
+        //given
+        Long userId = 1L;
+        UpdateUserNicknameRequest request = new UpdateUserNicknameRequest("new_nickname");
+
+        //when
+        ResultActions resultActions = mockMvc.perform(patch("/api/user/nickname")
+            .header("userId", userId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)));
+
+        //then
+        resultActions
+            .andDo(restDocs.document(
+                requestHeaders(
+                    headerWithName("userId").description("유저 아이디")
+                ),
+                requestFields(
+                    fieldWithPath("nickname").type(STRING).description("닉네임")
+                ),
+                responseFields(
+                    fieldWithPath("status").type(NUMBER).description("상태 코드"),
+                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                    fieldWithPath("message").type(STRING).description("메시지"),
+                    fieldWithPath("data").ignored()
+                )
+            ));
+    }
+
+}

--- a/src/test/java/com/lovemarker/domain/user/fixture/UserFixture.java
+++ b/src/test/java/com/lovemarker/domain/user/fixture/UserFixture.java
@@ -5,7 +5,7 @@ import com.lovemarker.domain.user.vo.SocialType;
 
 public class UserFixture {
 
-    public static final String NICKNAME = "nickname";
+    public static final String NICKNAME = "닉네임";
     public static final String SOCIAL_TOKEN = "test_token";
     public static final String PROVIDER = SocialType.GOOGLE.name();
 

--- a/src/test/java/com/lovemarker/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/lovemarker/domain/user/repository/UserRepositoryTest.java
@@ -90,4 +90,39 @@ class UserRepositoryTest extends BaseRepositoryTest {
             assertThat(result).isFalse();
         }
     }
+
+    @Nested
+    @DisplayName("existsByNickname_Nickname 메서드 실행 시")
+    class ExistsByNickname_NicknameTest {
+
+        @Test
+        @DisplayName("성공: true")
+        void existsByNickname_NicknameTrue() {
+            // given
+            User user = UserFixture.user();
+            userRepository.save(user);
+            String nickname = user.getNickname();
+
+            //when
+            boolean result = userRepository.existsByNickname_Nickname(nickname);
+
+            //then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("성공: false")
+        void existsByNickname_NicknameFalse() {
+            // given
+            User user = UserFixture.user();
+            userRepository.save(user);
+            String nickname = "new";
+
+            //when
+            boolean result = userRepository.existsByNickname_Nickname(nickname);
+
+            //then
+            assertThat(result).isFalse();
+        }
+    }
 }

--- a/src/test/java/com/lovemarker/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/lovemarker/domain/user/service/UserServiceTest.java
@@ -1,0 +1,80 @@
+package com.lovemarker.domain.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import com.lovemarker.domain.user.User;
+import com.lovemarker.domain.user.exception.UserNicknameDuplicateException;
+import com.lovemarker.domain.user.exception.UserNotFoundException;
+import com.lovemarker.domain.user.fixture.UserFixture;
+import com.lovemarker.domain.user.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @InjectMocks
+    UserService userService;
+
+    @Mock
+    UserRepository userRepository;
+
+    @Nested
+    @DisplayName("updateUserNickname 메서드 실행 시")
+    class UpdateUserNicknameTest {
+
+        User user = UserFixture.user();
+        String nickname = "new";
+
+        @Test
+        @DisplayName("성공")
+        void updateUserNickname() {
+            //given
+            given(userRepository.existsByNickname_Nickname(any())).willReturn(false);
+            given(userRepository.findById(anyLong())).willReturn(Optional.ofNullable(user));
+
+            //when
+            userService.updateUserNickname(1L, nickname);
+
+            //then
+            assertThat(user.getNickname()).isEqualTo(nickname);
+        }
+
+        @Test
+        @DisplayName("예외(UserNicknameDuplicateException): 중복된 닉네임")
+        void exceptionWhenNicknameIsDuplicated() {
+            //given
+            given(userRepository.existsByNickname_Nickname(any())).willReturn(true);
+
+            //when
+            Exception exception = catchException(() -> userService.updateUserNickname(1L, nickname));
+
+            //then
+            assertThat(exception).isInstanceOf(UserNicknameDuplicateException.class);
+        }
+
+        @Test
+        @DisplayName("예외(UserNotFoundException): 존재하지 않는 유저")
+        void exceptionWhenUserIsNull() {
+            //given
+            given(userRepository.existsByNickname_Nickname(any())).willReturn(false);
+
+            //when
+            Exception exception = catchException(() -> userService.updateUserNickname(1L, nickname));
+
+            //then
+            assertThat(exception).isInstanceOf(UserNotFoundException.class);
+        }
+
+    }
+}

--- a/src/test/java/com/lovemarker/domain/user/vo/UserNicknameTest.java
+++ b/src/test/java/com/lovemarker/domain/user/vo/UserNicknameTest.java
@@ -54,7 +54,7 @@ class UserNicknameTest {
         }
 
         @Test
-        @DisplayName("예외(BadRequestException): 닉네임 10자 초과")
+        @DisplayName("예외(BadRequestException): 닉네임 8자 초과")
         void exceptionWhenNicknameLengthOver10() {
             //given
             String nickname = "test_nickname";


### PR DESCRIPTION
### ⛏ 작업 사항
닉네임 변경 API

### 📝 작업 요약
- 닉네임 변경을 위한 controller, service, repository 메서드 작성
- 단위 테스트 작성
- 닉네임 8자 제한 변경

### 💡 관련 이슈
- close #16 
