### PR TITLE
feat: 추억 목록 리스트뷰 조회 API 

### DIFF
--- a/src/main/java/com/lovemarker/domain/memory/controller/MemoryController.java
+++ b/src/main/java/com/lovemarker/domain/memory/controller/MemoryController.java
@@ -3,6 +3,7 @@ package com.lovemarker.domain.memory.controller;
 import com.lovemarker.domain.memory.dto.request.CreateMemoryRequest;
 import com.lovemarker.domain.memory.dto.response.CreateMemoryResponse;
 import com.lovemarker.domain.memory.dto.response.FindMemoryDetail;
+import com.lovemarker.domain.memory.dto.response.FindMemoryListResponse;
 import com.lovemarker.domain.memory.service.MemoryService;
 import com.lovemarker.global.config.resolver.UserId;
 import com.lovemarker.global.constant.SuccessCode;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -45,5 +47,13 @@ public class MemoryController {
     ) {
         return ApiResponseDto.success(SuccessCode.FIND_MEMORY_DETAIL_SUCCESS,
             memoryService.findMemoryDetail(userId, memoryId));
+    }
+
+    @GetMapping("/list-view")
+    public ApiResponseDto<FindMemoryListResponse> findMemoryList(
+        @UserId Long userId, @RequestParam int page, @RequestParam int size
+    ) {
+        return ApiResponseDto.success(SuccessCode.FIND_MEMORY_LIST_SUCCESS,
+            memoryService.findMemoryList(userId, page, size));
     }
 }

--- a/src/main/java/com/lovemarker/domain/memory/dto/response/FindMemoryListResponse.java
+++ b/src/main/java/com/lovemarker/domain/memory/dto/response/FindMemoryListResponse.java
@@ -1,0 +1,33 @@
+package com.lovemarker.domain.memory.dto.response;
+
+import com.lovemarker.domain.memory.Memory;
+import com.lovemarker.global.dto.PageInfo;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record FindMemoryListResponse(
+    PageInfo pageInfo,
+    List<FindMemoryResponse> memories
+) {
+
+    public record FindMemoryResponse(
+        Long memoryId,
+        String title,
+        LocalDate date,
+        String address,
+        String image
+    ) {
+        public static FindMemoryResponse from(Memory memory) {
+            return new FindMemoryResponse(memory.getMemoryId(), memory.getTitle(), memory.getDate(),
+                memory.getAddressInfo().getAddress(), memory.getImages().get(0));
+        }
+    }
+
+    public static FindMemoryListResponse from(Page<Memory> memories) {
+        PageInfo pageInfo = PageInfo.of(memories.getTotalElements(), memories.hasNext());
+        List<FindMemoryResponse> findMemoryResponses = memories.get()
+            .map(FindMemoryResponse::from).toList();
+        return new FindMemoryListResponse(pageInfo, findMemoryResponses);
+    }
+}

--- a/src/main/java/com/lovemarker/domain/memory/repository/MemoryRepository.java
+++ b/src/main/java/com/lovemarker/domain/memory/repository/MemoryRepository.java
@@ -1,8 +1,12 @@
 package com.lovemarker.domain.memory.repository;
 
 import com.lovemarker.domain.memory.Memory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemoryRepository extends JpaRepository<Memory, Long> {
+
+    Page<Memory> findByCouple_CoupleIdOrderByCreatedAtDesc(Long coupleId, Pageable pageable);
 
 }

--- a/src/main/java/com/lovemarker/domain/memory/service/MemoryService.java
+++ b/src/main/java/com/lovemarker/domain/memory/service/MemoryService.java
@@ -1,8 +1,10 @@
 package com.lovemarker.domain.memory.service;
 
+import com.lovemarker.domain.couple.Couple;
 import com.lovemarker.domain.memory.Memory;
 import com.lovemarker.domain.memory.dto.response.CreateMemoryResponse;
 import com.lovemarker.domain.memory.dto.response.FindMemoryDetail;
+import com.lovemarker.domain.memory.dto.response.FindMemoryListResponse;
 import com.lovemarker.domain.memory.exception.MemoryNotFoundException;
 import com.lovemarker.domain.memory.repository.MemoryRepository;
 import com.lovemarker.domain.user.User;
@@ -17,6 +19,8 @@ import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,6 +47,17 @@ public class MemoryService {
     public FindMemoryDetail findMemoryDetail(Long userId, Long memoryId) {
         Memory memory = getMemoryByMemoryId(memoryId);
         return FindMemoryDetail.of(memory, Objects.equals(memory.getUser().getUserId(), userId));
+    }
+
+    @Transactional(readOnly = true)
+    @CouplePermissionCheck
+    public FindMemoryListResponse findMemoryList(Long userId, int page, int size) {
+        User user = getUserByUserId(userId);
+        Couple couple = user.getCouple();
+        PageRequest pageRequest = PageRequest.of(page, size);
+        Page<Memory> memories = memoryRepository.findByCouple_CoupleIdOrderByCreatedAtDesc(
+            couple.getCoupleId(), pageRequest);
+        return FindMemoryListResponse.from(memories);
     }
 
     private User getUserByUserId(Long userId) {

--- a/src/main/java/com/lovemarker/global/constant/SuccessCode.java
+++ b/src/main/java/com/lovemarker/global/constant/SuccessCode.java
@@ -14,6 +14,7 @@ public enum SuccessCode {
     UPDATE_USER_NICKNAME_SUCCESS(HttpStatus.OK, "닉네임 변경에 성공했습니다."),
     FIND_MY_PAGE_SUCCESS(HttpStatus.OK, "마이페이지 조회에 성공했습니다."),
     FIND_MEMORY_DETAIL_SUCCESS(HttpStatus.OK, "추억 상세 조회에 성공했습니다."),
+    FIND_MEMORY_LIST_SUCCESS(HttpStatus.OK, "추억 리스트뷰 조회에 성공했습니다."),
 
     // 201
     CREATE_INVITATION_CODE_SUCCESS(HttpStatus.CREATED, "초대 코드 생성을 성공했습니다."),

--- a/src/main/java/com/lovemarker/global/dto/PageInfo.java
+++ b/src/main/java/com/lovemarker/global/dto/PageInfo.java
@@ -1,0 +1,8 @@
+package com.lovemarker.global.dto;
+
+public record PageInfo(long totalElements, boolean hasNext) {
+
+    public static PageInfo of(long totalElements, boolean hasNext) {
+        return new PageInfo(totalElements, hasNext);
+    }
+}

--- a/src/test/java/com/lovemarker/base/BaseRepositoryTest.java
+++ b/src/test/java/com/lovemarker/base/BaseRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.lovemarker.base;
 
 import com.lovemarker.domain.couple.repository.CoupleRepository;
+import com.lovemarker.domain.memory.repository.MemoryRepository;
 import com.lovemarker.domain.user.repository.UserRepository;
 import jakarta.persistence.EntityManager;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,4 +18,7 @@ public abstract class BaseRepositoryTest {
 
     @Autowired
     protected CoupleRepository coupleRepository;
+
+    @Autowired
+    protected MemoryRepository memoryRepository;
 }

--- a/src/test/java/com/lovemarker/domain/memory/controller/MemoryControllerTest.java
+++ b/src/test/java/com/lovemarker/domain/memory/controller/MemoryControllerTest.java
@@ -4,6 +4,7 @@ import static javax.management.openmbean.SimpleType.BOOLEAN;
 import static javax.management.openmbean.SimpleType.STRING;
 import static javax.swing.text.html.parser.DTDConstants.NUMBER;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
@@ -13,15 +14,21 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 
 import com.lovemarker.base.BaseControllerTest;
 import com.lovemarker.domain.memory.dto.response.FindMemoryDetail;
+import com.lovemarker.domain.memory.dto.response.FindMemoryListResponse;
+import com.lovemarker.domain.memory.dto.response.FindMemoryListResponse.FindMemoryResponse;
+import com.lovemarker.global.dto.PageInfo;
 import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 class MemoryControllerTest extends BaseControllerTest {
 
@@ -62,6 +69,52 @@ class MemoryControllerTest extends BaseControllerTest {
                     fieldWithPath("data.writer").type(STRING).description("작성자 닉네임"),
                     fieldWithPath("data.isWriter").type(BOOLEAN).description("작성 여부"),
                     fieldWithPath("data.images[]").type(ARRAY).description("이미지")
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("성공: 추억 리스트뷰 조회 api 호출 시")
+    void findMemoryList() throws Exception {
+        //given
+        Long userId = 1L;
+        FindMemoryResponse findMemoryResponse = new FindMemoryResponse(1L, "title",
+            LocalDate.now(), "address", "url");
+        PageInfo pageInfo = new PageInfo(1, false);
+        FindMemoryListResponse response = new FindMemoryListResponse(pageInfo, List.of(findMemoryResponse));
+
+        given(memoryService.findMemoryList(any(), anyInt(), anyInt())).willReturn(response);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("page", "0");
+        params.add("size", "10");
+
+        //when
+        ResultActions resultActions = mockMvc.perform(get("/api/memory/list-view")
+            .header("userId", userId)
+            .params(params));
+
+        //then
+        resultActions.andDo(
+            restDocs.document(
+                requestHeaders(
+                    headerWithName("userId").description("유저 아이디")
+                ),
+                queryParameters(
+                    parameterWithName("page").description("page"),
+                    parameterWithName("size").description("size")
+                ),
+                responseFields(
+                    fieldWithPath("status").type(NUMBER).description("상태 코드"),
+                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                    fieldWithPath("message").type(STRING).description("메시지"),
+                    fieldWithPath("data.pageInfo.totalElements").type(NUMBER).description("총 데이터 수"),
+                    fieldWithPath("data.pageInfo.hasNext").type(BOOLEAN).description("다음 페이지 존재 여부"),
+                    fieldWithPath("data.memories[].memoryId").type(NUMBER).description("추억 ID"),
+                    fieldWithPath("data.memories[].title").type(STRING).description("제목"),
+                    fieldWithPath("data.memories[].date").type(STRING).description("날짜"),
+                    fieldWithPath("data.memories[].address").type(STRING).description("주소"),
+                    fieldWithPath("data.memories[].image").type(STRING).description("대표 이미지")
                 )
             ));
     }

--- a/src/test/java/com/lovemarker/domain/memory/repository/MemoryRepositoryTest.java
+++ b/src/test/java/com/lovemarker/domain/memory/repository/MemoryRepositoryTest.java
@@ -1,0 +1,53 @@
+package com.lovemarker.domain.memory.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.lovemarker.base.BaseRepositoryTest;
+import com.lovemarker.domain.couple.Couple;
+import com.lovemarker.domain.couple.fixture.CoupleFixture;
+import com.lovemarker.domain.memory.Memory;
+import com.lovemarker.domain.memory.fixture.MemoryFixture;
+import com.lovemarker.domain.user.User;
+import com.lovemarker.domain.user.fixture.UserFixture;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+class MemoryRepositoryTest extends BaseRepositoryTest {
+
+    @Nested
+    @DisplayName("findByCouple_CoupleIdOrderByCreatedAtDesc 메서드 실행 시")
+    class FindByCouple_CoupleIdOrderByCreatedAtDescTest {
+
+        @Test
+        @DisplayName("성공")
+        void findByCouple_CoupleIdOrderByCreatedAtDesc() {
+            //given
+            User user = UserFixture.user();
+            Couple couple = CoupleFixture.couple();
+            user.connectCouple(couple);
+            Memory memory = MemoryFixture.memory(user);
+
+            userRepository.save(user);
+            coupleRepository.save(couple);
+            memoryRepository.save(memory);
+
+            PageRequest pageRequest = PageRequest.of(0, 10);
+            List<Memory> memoryList = List.of(memory);
+            Page<Memory> expected = new PageImpl<>(memoryList);
+
+            //when
+            Page<Memory> result = memoryRepository
+                .findByCouple_CoupleIdOrderByCreatedAtDesc(couple.getCoupleId(), pageRequest);
+
+            //then
+            Assertions.assertThat(result.getTotalElements()).isEqualTo(expected.getTotalElements());
+        }
+    }
+
+}


### PR DESCRIPTION
### ⛏ 작업 사항
추억 목록 리스트뷰 데이터를 pagination과 createdAt 내림차순으로 반환한다.

### 📝 작업 요약
- 추억 목록 리스트뷰 조회 response DTO
- 추억 목록 리스트뷰 조회를 위한 controller, service, repository 메서드 작성
- 각 단위 테스트 작성

### 💡 관련 이슈
- close #24 
