### PR TITLE
feat: 커플 연결 해제 API

### DIFF
--- a/src/main/java/com/lovemarker/domain/couple/controller/CoupleController.java
+++ b/src/main/java/com/lovemarker/domain/couple/controller/CoupleController.java
@@ -9,6 +9,7 @@ import com.lovemarker.global.constant.SuccessCode;
 import com.lovemarker.global.dto.ApiResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,5 +38,13 @@ public class CoupleController {
     ) {
         coupleService.joinCouple(userId, joinCoupleRequest.invitationCode());
         return ApiResponseDto.success(SuccessCode.JOIN_COUPLE_SUCCESS);
+    }
+
+    @DeleteMapping
+    public ApiResponseDto disconnectCouple(
+        @UserId Long userId
+    ) {
+        coupleService.disconnectCouple(userId);
+        return ApiResponseDto.success(SuccessCode.DISCONNECT_COUPLE_SUCCESS);
     }
 }

--- a/src/main/java/com/lovemarker/domain/couple/service/CoupleService.java
+++ b/src/main/java/com/lovemarker/domain/couple/service/CoupleService.java
@@ -7,6 +7,7 @@ import com.lovemarker.domain.couple.repository.CoupleRepository;
 import com.lovemarker.domain.user.User;
 import com.lovemarker.domain.user.exception.UserNotFoundException;
 import com.lovemarker.domain.user.repository.UserRepository;
+import com.lovemarker.global.aspect.CouplePermissionCheck;
 import com.lovemarker.global.constant.ErrorCode;
 import com.lovemarker.global.exception.BadRequestException;
 import com.lovemarker.global.exception.NotFoundException;
@@ -38,6 +39,13 @@ public class CoupleService {
         Couple couple = getCoupleByInviteCode(invitationCode);
         validateJoinCouple(couple.getCoupleId());
         user.connectCouple(couple);
+    }
+
+    @Transactional
+    @CouplePermissionCheck
+    public void disconnectCouple(Long userId) {
+        User user = getUserByUserId(userId);
+        user.disconnectCouple();
     }
 
     private User getUserByUserId(Long userId) {

--- a/src/main/java/com/lovemarker/domain/user/User.java
+++ b/src/main/java/com/lovemarker/domain/user/User.java
@@ -59,6 +59,10 @@ public class User extends BaseTimeEntity {
         this.couple = couple;
     }
 
+    public void disconnectCouple() {
+        this.couple = null;
+    }
+
     public void updateUserNickname(String nickname) {
         this.nickname = new UserNickname(nickname);
     }

--- a/src/main/java/com/lovemarker/global/constant/SuccessCode.java
+++ b/src/main/java/com/lovemarker/global/constant/SuccessCode.java
@@ -16,6 +16,7 @@ public enum SuccessCode {
     FIND_MEMORY_DETAIL_SUCCESS(HttpStatus.OK, "추억 상세 조회에 성공했습니다."),
     FIND_MEMORY_LIST_SUCCESS(HttpStatus.OK, "추억 리스트뷰 조회에 성공했습니다."),
     FIND_MY_MEMORY_LIST_SUCCESS(HttpStatus.OK, "내가 올린 추억 조회에 성공했습니다."),
+    DISCONNECT_COUPLE_SUCCESS(HttpStatus.OK, "커플 연결 해제에 성공했습니다."),
 
     // 201
     CREATE_INVITATION_CODE_SUCCESS(HttpStatus.CREATED, "초대 코드 생성을 성공했습니다."),

--- a/src/test/java/com/lovemarker/domain/couple/controller/CoupleControllerTest.java
+++ b/src/test/java/com/lovemarker/domain/couple/controller/CoupleControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.requestHe
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 import com.lovemarker.base.BaseControllerTest;
@@ -80,6 +81,31 @@ class CoupleControllerTest extends BaseControllerTest {
                 ),
                 requestFields(
                     fieldWithPath("invitationCode").type(STRING).description("초대 코드")
+                ),
+                responseFields(
+                    fieldWithPath("status").type(NUMBER).description("상태 코드"),
+                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                    fieldWithPath("message").type(STRING).description("메시지"),
+                    fieldWithPath("data").ignored()
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("성공: 커플 연결 해제 api 호출 시")
+    void disconnectCouple() throws Exception {
+        //given
+        Long userId = 1L;
+
+        //when
+        ResultActions resultActions = mockMvc.perform(delete("/api/couple")
+            .header("userId", userId));
+
+        //then
+        resultActions
+            .andDo(restDocs.document(
+                requestHeaders(
+                    headerWithName("userId").description("유저 아이디")
                 ),
                 responseFields(
                     fieldWithPath("status").type(NUMBER).description("상태 코드"),

--- a/src/test/java/com/lovemarker/domain/couple/service/CoupleServiceTest.java
+++ b/src/test/java/com/lovemarker/domain/couple/service/CoupleServiceTest.java
@@ -12,6 +12,7 @@ import com.lovemarker.domain.couple.InviteCodeStrategy;
 import com.lovemarker.domain.couple.fixture.CoupleFixture;
 import com.lovemarker.domain.couple.repository.CoupleRepository;
 import com.lovemarker.domain.user.User;
+import com.lovemarker.domain.user.exception.UserNotFoundException;
 import com.lovemarker.domain.user.fixture.UserFixture;
 import com.lovemarker.domain.user.repository.UserRepository;
 import com.lovemarker.global.exception.BadRequestException;
@@ -132,6 +133,40 @@ class CoupleServiceTest {
 
             //then
             assertThat(exception).isInstanceOf(BadRequestException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("disconnectCouple 메서드 실행 시")
+    class DisconnectCoupleTest {
+
+        User user = UserFixture.user();
+        Couple couple = CoupleFixture.couple();
+
+        @Test
+        @DisplayName("성공")
+        void disconnectCouple() {
+            //given
+            user.connectCouple(couple);
+
+            given(userRepository.findById(anyLong())).willReturn(Optional.ofNullable(user));
+
+            //when
+            coupleService.disconnectCouple(1L);
+
+            //then
+            assertThat(user.getCouple()).isEqualTo(null);
+        }
+
+        @Test
+        @DisplayName("예외(UserNotFoundException): 존재하지 않는 유저")
+        void exceptionWhenUserNotFound() {
+            //given
+            //when
+            Exception exception = catchException(() -> coupleService.disconnectCouple(1L));
+
+            //then
+            assertThat(exception).isInstanceOf(UserNotFoundException.class);
         }
     }
 }

--- a/src/test/java/com/lovemarker/domain/user/UserTest.java
+++ b/src/test/java/com/lovemarker/domain/user/UserTest.java
@@ -79,4 +79,25 @@ class UserTest {
             assertThat(exception).isInstanceOf(BadRequestException.class);
         }
     }
+
+    @Nested
+    @DisplayName("커플 연결 해제 시")
+    class DisconnectCoupleTest {
+
+        User user = UserFixture.user();
+        Couple couple = CoupleFixture.couple();
+
+        @Test
+        @DisplayName("성공")
+        void disconnectCouple() {
+            //given
+            user.connectCouple(couple);
+
+            //when
+            user.disconnectCouple();
+
+            //then
+            assertThat(user.getCouple()).isNull();
+        }
+    }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
커플 연결 해제 API

### 📝 작업 요약
- 커플 연결 해제를 위한 controller, service, 도메인 메서드 작성
- 각 단위 테스트 작성

### 💡 관련 이슈
- close #33 
