### PR TITLE
Feat/#41

### DIFF
--- a/src/main/java/com/lovemarker/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/lovemarker/domain/auth/controller/AuthController.java
@@ -25,10 +25,11 @@ public class AuthController {
 
     @PostMapping
     public ApiResponseDto<SignInResponse> signIn(
+        @RequestHeader @NotBlank String token,
         @Valid @RequestBody final SignInRequest signInRequest
     ) {
         return ApiResponseDto.success(SuccessCode.LOGIN_SUCCESS,
-            authService.signIn(signInRequest.token(), signInRequest.provider()));
+            authService.signIn(token, signInRequest.provider()));
     }
 
     @GetMapping("/reissue-token")

--- a/src/main/java/com/lovemarker/domain/auth/dto/request/SignInRequest.java
+++ b/src/main/java/com/lovemarker/domain/auth/dto/request/SignInRequest.java
@@ -3,7 +3,6 @@ package com.lovemarker.domain.auth.dto.request;
 import jakarta.validation.constraints.NotBlank;
 
 public record SignInRequest(
-    @NotBlank(message = "토큰은 필수 입력 항목입니다.") String token,
     @NotBlank(message = "provider는 필수 입력 항목입니다.") String provider
 ) {
 

--- a/src/main/java/com/lovemarker/domain/couple/service/CoupleService.java
+++ b/src/main/java/com/lovemarker/domain/couple/service/CoupleService.java
@@ -7,7 +7,6 @@ import com.lovemarker.domain.couple.repository.CoupleRepository;
 import com.lovemarker.domain.user.User;
 import com.lovemarker.domain.user.exception.UserNotFoundException;
 import com.lovemarker.domain.user.repository.UserRepository;
-import com.lovemarker.global.aspect.CouplePermissionCheck;
 import com.lovemarker.global.constant.ErrorCode;
 import com.lovemarker.global.exception.BadRequestException;
 import com.lovemarker.global.exception.NotFoundException;
@@ -42,7 +41,6 @@ public class CoupleService {
     }
 
     @Transactional
-    @CouplePermissionCheck
     public void disconnectCouple(Long userId) {
         User user = getUserByUserId(userId);
         user.disconnectCouple();

--- a/src/main/java/com/lovemarker/global/config/resolver/UserIdResolver.java
+++ b/src/main/java/com/lovemarker/global/config/resolver/UserIdResolver.java
@@ -31,9 +31,8 @@ public class UserIdResolver implements HandlerMethodArgumentResolver {
     public Object resolveArgument(@NotNull MethodParameter parameter, ModelAndViewContainer modelAndViewContainer, @NotNull NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         final HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         String accessToken = request.getHeader("accessToken");
-        String refreshToken = request.getHeader("refreshToken");
 
-        if (accessToken == null || refreshToken == null) {
+        if (accessToken == null) {
             throw new NullAccessTokenException(ErrorCode.NULL_ACCESS_TOKEN_EXCEPTION, ErrorCode.NULL_ACCESS_TOKEN_EXCEPTION.getMessage());
         }
 


### PR DESCRIPTION
### ⛏ 작업 사항
- auth API 소셜 토큰 header로 요청
- request header에 refreshToken nullable
- 커플 연결 해제 API 커플 권한 체크 기능 제거

### 📝 작업 요약


### 💡 관련 이슈
- close #41 
